### PR TITLE
Make CDC logging reliable and fix docker ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # pico USB CDC+HID template
-rpi pico USB CDC+HID template
 
 `PID=0x4005`
 `VID=0xACDC`
@@ -15,18 +14,18 @@ docker pull xianii/pico-sdk:latest
 ### build
 
 ```shell
-# build
+# build (docker, files owned by your user)
 make
-# clang-format
+# remove root-owned build/ from earlier docker runs
+make docker_clean
+# or: make clean  (falls back to docker_clean if build/ is not writable)
 make format
-# clear build
-make clean
-# rebuild
 make rebuild
 ```
 
 ## Usage
 
-- Pico will enumerate two USB devices, specifically a `CDC` device and an `HID` device. 
-- The log will be printed out via the `CDC` serial port. 
-- Any data frame written to the `HID` device will be printed out from the `CDC` serial port, and the `HID` will also return a data frame with each byte incremented by 1.
+- Pico enumerates CDC and HID.
+- Logs go out CDC via a 1 KB ring drained in the main loop (timer IRQ never writes USB).
+- CDC `UPLOAD` + newline reboots to UF2 bootloader.
+- Any HID OUT report is logged on CDC and echoed back with each byte incremented by 1.

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 
 BUILD_DIR = build
 
-.PHONY: clean default build rebuild
+.PHONY: clean default build rebuild format docker_build docker_clean
 
 default: docker_build
 
@@ -10,16 +10,27 @@ build:
 	cmake . -G Ninja -B$(BUILD_DIR) -S.
 	ninja -C $(BUILD_DIR)
 
+# Host clean; if build/ is root-owned from docker, falls back to docker_clean.
 clean:
-	@if [ -d "./$(BUILD_DIR)" ]; then rm ./$(BUILD_DIR) -rf; fi
+	@if [ ! -d "./$(BUILD_DIR)" ]; then exit 0; fi; \
+	if [ -w "./$(BUILD_DIR)" ]; then rm -rf "./$(BUILD_DIR)"; \
+	else $(MAKE) docker_clean; fi
 
 rebuild: clean build
 
 format:
 	bash format.sh
 
-.PHONY: docker_build
-docker_build:
+docker_clean:
 	docker run --rm \
 	-v ${PWD}:/workspace \
-	xianii/pico-sdk:latest /bin/bash -c "cd pico-src && cmake . -G Ninja -Bbuild -S. && ninja -C build"
+	-w /workspace \
+	xianii/pico-sdk:latest rm -rf build
+
+docker_build:
+	docker run --rm \
+	-u $(shell id -u):$(shell id -g) \
+	-e HOME=/tmp \
+	-v ${PWD}:/workspace \
+	-w /workspace \
+	xianii/pico-sdk:latest /bin/bash -c "cmake . -G Ninja -Bbuild -S. && ninja -C build"

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,7 @@
 
 #include "pico/stdlib.h"
 #include "hardware/sync.h"
+#include <string.h>
 
 #include "scheduler/uevent.h"
 #include "scheduler/scheduler.h"
@@ -26,7 +27,8 @@ static __inline void CRITICAL_REGION_EXIT(void) {
 }
 
 bool timer_4hz_callback(struct repeating_timer* t) {
-	LOG_RAW("At %lld us:\n", time_us_64());
+	(void)t;
+	// IRQ: only queue the event — never touch TinyUSB / LOG_RAW here.
 	uevt_bc_e(UEVT_TIMER_4HZ);
 	return true;
 }
@@ -67,38 +69,39 @@ void hid_receive(uint8_t const* buffer, uint16_t bufsize) {
 		str[i * 2] = printHex[buffer[i] >> 4];
 		str[i * 2 + 1] = printHex[buffer[i] & 0xF];
 	}
-	// print first 32 bytes
 	LOG_RAW("HID[%d]:%s\n", bufsize, str);
 
 	uint8_t echo[64];
-	// echo back with every byte + 1
-	for (uint16_t i = 0; i < bufsize; i++) {
+	for(uint16_t i = 0; i < bufsize; i++)
 		echo[i] = buffer[i] + 1;
-	}
 	hid_send(echo, bufsize);
 }
 
-static char serial_fifo[16];
-static uint8_t serial_wp = 0;
-uint8_t serial_got(const char* str) {
-	uint8_t len = strlen(str);
-	for(uint8_t i = 1; i <= len; i++) {
-		if(serial_fifo[serial_wp + (0x10 - i) & 0xF] != str[len - i]) {
-			return 0;
-		}
+static char serial_line[40];
+static uint8_t serial_line_len;
+
+static void serial_handle_line(const char* line) {
+	if(strcmp(line, "UPLOAD") == 0) {
+		ws2812_setpixel(U32RGB(20, 0, 20));
+		reset_usb_boot(0, 0);
 	}
-	return 1;
 }
+
 void serial_receive(uint8_t const* buffer, uint16_t bufsize) {
 	for(uint16_t i = 0; i < bufsize; i++) {
-		if((*buffer == 0x0A) || (*buffer == 0x0D)) {
-			if(serial_got("UPLOAD")) {
-				ws2812_setpixel(U32RGB(20, 0, 20));
-				reset_usb_boot(0, 0);
+		uint8_t c = buffer[i];
+		if(c == '\n' || c == '\r') {
+			if(serial_line_len > 0) {
+				serial_line[serial_line_len] = 0;
+				serial_handle_line(serial_line);
+				serial_line_len = 0;
 			}
-		} else {
-			serial_fifo[serial_wp++ & 0xF] = *buffer++;
+			continue;
 		}
+		if(serial_line_len + 1u < sizeof(serial_line))
+			serial_line[serial_line_len++] = (char)c;
+		else
+			serial_line_len = 0;
 	}
 }
 
@@ -117,6 +120,7 @@ int main() {
 	add_repeating_timer_us(249978ul, timer_4hz_callback, NULL, &timer);
 	tusb_init();
 	cdc_log_init();
+	LOG_RAW("idle: UPLOAD + newline\n");
 	while(true) {
 		app_sched_execute();
 		tud_task();

--- a/src/platform.c
+++ b/src/platform.c
@@ -3,24 +3,17 @@
 #include "usb_func.h"
 
 char log_cache[128] = { 0 };
-char log_buffer[512] = { 0 };
-uint16_t log_ptr = 0;
-int16_t log_length = 0;
 
 #include <stdarg.h>
 void remote_log(const char* format, ...) {
 #if G_LOG_ENABLED == 1
 	va_list args;
 	va_start(args, format);
-	log_length = sprintf(log_cache, format, args) + 1;
-	if(log_length > 1) {
-		if(log_ptr + log_length >= 512) {
-			log_ptr = 0;
-		}
-		memcpy(log_buffer + log_ptr, log_cache, log_length);
-		cdc_log_print(log_buffer + log_ptr);
-		log_ptr += log_length;
-	}
+	int n = vsnprintf(log_cache, sizeof(log_cache), format, args);
 	va_end(args);
+	if(n > 0)
+		cdc_log_enqueue(log_cache, (uint16_t)n);
+#else
+	(void)format;
 #endif
 }

--- a/src/platform.h
+++ b/src/platform.h
@@ -1,29 +1,21 @@
-
 #ifndef _PLATFORM_H_
 #define _PLATFORM_H_
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
 #include "tusb.h"
 #include "usb_func.h"
 #include "scheduler/uevent.h"
 
 #if G_LOG_ENABLED == 1
 extern char log_cache[128];
-extern char log_buffer[512];
-extern uint16_t log_ptr;
-extern int16_t log_length;
 	#define LOG_RAW(...) \
 		do { \
-			log_length = sprintf(log_cache, __VA_ARGS__) + 1; \
-			if(log_length > 1) { \
-				if(log_ptr + log_length >= 512) { \
-					log_ptr = 0; \
-				} \
-				memcpy(log_buffer + log_ptr, log_cache, log_length); \
-				cdc_log_print(log_buffer + log_ptr); \
-				log_ptr += log_length; \
-			} \
-		} while(0);
+			int _n = snprintf(log_cache, sizeof(log_cache), __VA_ARGS__); \
+			if(_n > 0) \
+				cdc_log_enqueue(log_cache, (uint16_t)_n); \
+		} while(0)
 #else
 	#define LOG_RAW(...)
 #endif

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -93,8 +93,8 @@ extern "C" {
 #define CFG_TUD_HID_EP_BUFSIZE (64)
 
 // CDC FIFO size of TX and RX
-#define CFG_TUD_CDC_RX_BUFSIZE (64)
-#define CFG_TUD_CDC_TX_BUFSIZE (64)
+#define CFG_TUD_CDC_RX_BUFSIZE (256)
+#define CFG_TUD_CDC_TX_BUFSIZE (512)
 
 // CDC Endpoint transfer buffer size, more is faster
 #define CFG_TUD_CDC_EP_BUFSIZE (64)

--- a/src/usb_func.c
+++ b/src/usb_func.c
@@ -1,25 +1,77 @@
-
 #include "tusb.h"
 #include "tusb_config.h"
+#include "hardware/sync.h"
 
 #include "string.h"
 
 volatile bool usb_mounted = false;
+
+void serial_receive(uint8_t const* buffer, uint16_t bufsize);
+void hid_receive(uint8_t const* buffer, uint16_t bufsize);
+
 //--------------------------------------------------------------------+
-// CDC Funcs
+// CDC log ring — enqueue from any context; drain only from main loop
 //--------------------------------------------------------------------+
 
-__attribute__((weak)) void serial_receive(uint8_t const* buffer, uint16_t bufsize) {
+#define CDC_LOG_RING 1024u
+
+static uint8_t log_ring[CDC_LOG_RING];
+static volatile uint16_t log_w;
+static volatile uint16_t log_r;
+static volatile uint32_t log_drop;
+
+static uint16_t ring_used(void) {
+	return (uint16_t)((log_w - log_r) & (CDC_LOG_RING - 1));
 }
 
-static uint16_t log_depth_max = 0;
+static uint16_t ring_free(void) {
+	return (uint16_t)(CDC_LOG_RING - 1u - ring_used());
+}
+
 void cdc_log_init(void) {
-	log_depth_max = tud_cdc_n_write_available(0);
+	log_w = 0;
+	log_r = 0;
+	log_drop = 0;
 }
-void cdc_log_flush(void) {
-	if(tud_cdc_n_write_available(0) < log_depth_max) {
-		tud_cdc_n_write_flush(0);
+
+void cdc_log_enqueue(const void* data, uint16_t len) {
+	if(len == 0 || data == NULL)
+		return;
+	uint32_t irq = save_and_disable_interrupts();
+	if(ring_free() < len) {
+		log_drop++;
+		restore_interrupts(irq);
+		return;
 	}
+	const uint8_t* p = (const uint8_t*)data;
+	for(uint16_t i = 0; i < len; i++) {
+		log_ring[log_w] = p[i];
+		log_w = (uint16_t)((log_w + 1u) & (CDC_LOG_RING - 1));
+	}
+	restore_interrupts(irq);
+}
+
+static void cdc_log_drain(void) {
+	if(!usb_mounted || !tud_cdc_n_connected(0))
+		return;
+	while(log_r != log_w) {
+		uint32_t avail = tud_cdc_n_write_available(0);
+		if(avail == 0) {
+			tud_cdc_n_write_flush(0);
+			break;
+		}
+		uint16_t used = ring_used();
+		uint16_t chunk = used;
+		if(chunk > avail)
+			chunk = (uint16_t)avail;
+		uint16_t to_end = (uint16_t)(CDC_LOG_RING - log_r);
+		if(chunk > to_end)
+			chunk = to_end;
+		tud_cdc_n_write(0, &log_ring[log_r], chunk);
+		log_r = (uint16_t)((log_r + chunk) & (CDC_LOG_RING - 1));
+	}
+	if(tud_cdc_n_write_available(0) < CFG_TUD_CDC_TX_BUFSIZE)
+		tud_cdc_n_write_flush(0);
 }
 
 void cdc_task(void) {
@@ -31,52 +83,54 @@ void cdc_task(void) {
 			serial_receive(buf, count);
 		}
 	}
-	cdc_log_flush();
-}
-
-static void serial_write(uint8_t itf, uint8_t buf[], uint32_t count) {
-	if(!usb_mounted) {
-		return;
-	}
-	if(tud_cdc_n_write_available(itf) < count) {
-		tud_cdc_n_write_flush(itf);
-	}
-	tud_cdc_n_write(itf, buf, count);
+	cdc_log_drain();
 }
 
 void cdc_log_print(char* str) {
-	if(!usb_mounted) {
+	if(str == NULL)
 		return;
+	cdc_log_enqueue(str, (uint16_t)strlen(str));
+}
+
+// Blocking write for rare dumps — waits until CDC has room so lines are not truncated.
+void cdc_log_print_wait(char* str) {
+	if(!usb_mounted || str == NULL)
+		return;
+	uint16_t len = (uint16_t)strlen(str);
+	uint16_t off = 0;
+	while(off < len) {
+		tud_task();
+		cdc_log_drain();
+		uint32_t avail = tud_cdc_n_write_available(0);
+		if(avail == 0) {
+			tud_cdc_n_write_flush(0);
+			continue;
+		}
+		uint16_t n = (uint16_t)(len - off);
+		if(n > avail)
+			n = (uint16_t)avail;
+		tud_cdc_n_write(0, str + off, n);
+		off = (uint16_t)(off + n);
 	}
-	uint16_t len = strlen(str);
-	if(tud_cdc_n_write_available(0) < len) {
-		tud_cdc_n_write_flush(0);
-	}
-	tud_cdc_n_write_str(0, str);
+	tud_cdc_n_write_flush(0);
 }
 
 //--------------------------------------------------------------------+
 // Device callbacks
 //--------------------------------------------------------------------+
 
-// Invoked when device is mounted
 void tud_mount_cb(void) {
 	usb_mounted = true;
 }
 
-// Invoked when device is unmounted
 void tud_umount_cb(void) {
 	usb_mounted = false;
 }
 
-// Invoked when usb bus is suspended
-// remote_wakeup_en : if host allow us  to perform remote wakeup
-// Within 7ms, device must draw an average of current less than 2.5 mA from bus
 void tud_suspend_cb(bool remote_wakeup_en) {
 	(void)remote_wakeup_en;
 }
 
-// Invoked when usb bus is resumed
 void tud_resume_cb(void) {
 	usb_mounted = tud_mounted() ? true : false;
 }
@@ -85,38 +139,34 @@ void tud_resume_cb(void) {
 // USB HID
 //--------------------------------------------------------------------+
 
-// Invoked when received GET_REPORT control request
-// Application must fill buffer report's content and return its length.
-// Return zero will cause the stack to STALL request
 uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen) {
-	// TODO not Implemented
 	(void)itf;
 	(void)report_id;
 	(void)report_type;
 	(void)buffer;
 	(void)reqlen;
-
 	return 0;
 }
 
-__attribute__((weak)) void hid_receive(uint8_t const* buffer, uint16_t bufsize) {
+__attribute__((weak)) void serial_receive(uint8_t const* buffer, uint16_t bufsize) {
+	(void)buffer;
+	(void)bufsize;
 }
+
+__attribute__((weak)) void hid_receive(uint8_t const* buffer, uint16_t bufsize) {
+	(void)buffer;
+	(void)bufsize;
+}
+
 void hid_send(uint8_t const* buffer, uint16_t bufsize) {
-	if(!usb_mounted) {
+	if(!usb_mounted)
 		return;
-	}
 	tud_hid_report(0, buffer, bufsize);
 }
 
-// Invoked when received SET_REPORT control request or
-// received data on OUT endpoint ( Report ID = 0, Type = 0 )
 void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) {
-	// This example doesn't use multiple report and report ID
 	(void)itf;
 	(void)report_id;
 	(void)report_type;
-
 	hid_receive(buffer, bufsize);
-	// echo back anything we received from host
-	// tud_hid_report(0, buffer, bufsize);
 }

--- a/src/usb_func.h
+++ b/src/usb_func.h
@@ -6,7 +6,9 @@
 extern volatile bool usb_mounted;
 void cdc_log_init(void);
 void cdc_task(void);
+void cdc_log_enqueue(const void* data, uint16_t len);
 void cdc_log_print(char* str);
+void cdc_log_print_wait(char* str);
 void hid_send(uint8_t const* buffer, uint16_t bufsize);
 
 #endif


### PR DESCRIPTION
## Summary
- Queue CDC logs into a 1 KB ring drained from the main loop; timer IRQ no longer writes USB.
- Grow CDC FIFOs, parse `UPLOAD` by line, and run docker builds as the current user with `docker_clean`.

## Test plan
- [ ] `make` produces a UF2 owned by the invoking user
- [ ] CDC logs blink LED without stalls; `UPLOAD` + newline enters bootloader
- [ ] HID echo still works and is logged on CDC


Made with [Cursor](https://cursor.com)